### PR TITLE
Subdued Brights, Added Shades

### DIFF
--- a/Patches/EditTagWindowPatch.cs
+++ b/Patches/EditTagWindowPatch.cs
@@ -11,15 +11,15 @@ namespace acidphantasm_moretagcolours.Patches
 
         public static readonly Color[] color_0 = new Color[]
         {
-            new Color(1f, 0f, 0f),
-            new Color(1f, 0.5f, 0f),
-            new Color(1f, 1f, 0f),
-            new Color(0.224f, 1f, 0f),
-            new Color(0f, 1f, 0.859f),
-            new Color(0f, 0.529f, 1f),
-            new Color(0.102f, 0f, 1f),
-            new Color(0.463f, 0f, 1f),
-            new Color(1f, 0f, 0.549f),
+            new Color(0.85f, 0f, 0f),
+            new Color(0.85f, 0.5f, 0f),
+            new Color(0.85f, 0.85f, 0f),
+            new Color(0.224f, 0.85f, 0f),
+            new Color(0f, 0.85f, 0.759f),
+            new Color(0f, 0.529f, 0.85f),
+            new Color(0.102f, 0f, 0.85f),
+            new Color(0.463f, 0f, 0.85f),
+            new Color(0.85f, 0f, 0.549f),
 
             new Color(0.349f, 0.122f, 0.122f),
             new Color(0.18f, 0.106f, 0.024f),
@@ -30,6 +30,16 @@ namespace acidphantasm_moretagcolours.Patches
             new Color(0.067f, 0.047f, 0.251f),
             new Color(0.165f, 0.051f, 0.302f),
             new Color(0.278f, 0.047f, 0.176f),
+
+            new Color(0.1f, 0.1f, 0.1f),
+            new Color(0.2f, 0.2f, 0.2f),
+            new Color(0.3f, 0.3f, 0.3f),
+            new Color(0.4f, 0.4f, 0.4f),
+            new Color(0.5f, 0.5f, 0.5f),
+            new Color(0.6f, 0.6f, 0.6f),
+            new Color(0.7f, 0.7f, 0.7f),
+            new Color(0.8f, 0.8f, 0.8f),
+            new Color(0.9f, 0.9f, 0.9f),
         };
 
         protected override MethodBase GetTargetMethod()


### PR DESCRIPTION
As the title says, I changed the super bright tags to be more in line with actually not destroying eyeballs by clashing with the white text used in the tag system. I also added a spectrum of shades: blacks, greys & whites, although the brighter whites are going to obviously clash with the text's colour.

Although dunno if this requires more than just editing this one patch file, so lemme know!